### PR TITLE
Fixed CEC issues (crash + support for multiple cmd sources)

### DIFF
--- a/cec/cec.js
+++ b/cec/cec.js
@@ -14,7 +14,7 @@ const parseCmd = require("./command-map");
 var
     cecProcess,         // cec process
     cecEmitter,         // cec event emitter
-    CEC_ADAPTER = {}   // logical address of cec adapter
+    CEC_ADAPTER = {}    // logical address of cec adapter
 ;
 
 var initialized = false;    // indicates if the CEC module is initialized
@@ -110,7 +110,6 @@ function registerEvents(cecProcess) {
                 CEC_ADAPTER.device = cecAdapterVals[1].substr(4);
                 CEC_ADAPTER.lAddr = cecAdapterVals[2][0];
                 console.log("CEC Adapter Device:\t" + JSON.stringify(CEC_ADAPTER, null, "  "));
-                console.log("CEC Base Device:\t" + JSON.stringify(CEC_BASE, null, "  "));
                 initialized = true;
                 // run after-init functions here:
                 testTVOn(cecProcess);

--- a/cec/cec.js
+++ b/cec/cec.js
@@ -14,8 +14,7 @@ const parseCmd = require("./command-map");
 var
     cecProcess,         // cec process
     cecEmitter,         // cec event emitter
-    CEC_ADAPTER = {},   // logical address of cec adapter
-    CEC_BASE = {}       // logical address of base device - will be TV (0) or audio receiver (5)
+    CEC_ADAPTER = {}   // logical address of cec adapter
 ;
 
 var initialized = false;    // indicates if the CEC module is initialized
@@ -110,8 +109,6 @@ function registerEvents(cecProcess) {
                 var cecBaseVals = initVals[5].split("(");
                 CEC_ADAPTER.device = cecAdapterVals[1].substr(4);
                 CEC_ADAPTER.lAddr = cecAdapterVals[2][0];
-                CEC_BASE.device = cecBaseVals[0].substr(11);
-                CEC_BASE.lAddr = cecBaseVals[1][0];
                 console.log("CEC Adapter Device:\t" + JSON.stringify(CEC_ADAPTER, null, "  "));
                 console.log("CEC Base Device:\t" + JSON.stringify(CEC_BASE, null, "  "));
                 initialized = true;
@@ -125,7 +122,7 @@ function registerEvents(cecProcess) {
         if (data.toString().includes(">>")) {
             var cecCmd = data.toString().split(">>")[1].replace(/\s+/g, "").split(":");
             // console.log(cecCmd);
-            if (cecCmd[0][0] == CEC_BASE.lAddr && cecCmd[0][1] == CEC_ADAPTER.lAddr) {  // device => adapter
+            if ((cecCmd[0][0] == 0 || cecCmd[0][0] == 5) && cecCmd[0][1] == CEC_ADAPTER.lAddr) {  // device => adapter
                 if (cecCmd[1] == "44") {    // key pressed
                     console.log("remote control button pressed");
                     remoteButton.state = 1;


### PR DESCRIPTION
I have had the problem that the application crashes if it's started while the TV is already powered on. This happens because the parser expects there to be reported a base device in the initialization string from the driver, but that is not the case when the TV is already powered on.

TV on:

```
CEC client registered: libCEC version = 3.0.0
client version = 3.0.0
firmware version = 4
firmware build date: Thu Dec 06 11:15:20 2012 +0000
logical address(es) = Recorder 1 (1) 
physical address: 1.1.0.0
compiled on Windows-6.2 (x64)
features: P8_USB
P8_detect
```

TV off:

```
CEC client registered: libCEC version = 3.0.0
client version = 3.0.0
firmware version = 4
firmware build date: Thu Dec 06 11:15:20 2012 +0000
logical address(es) = Recorder 1 (1) 
base device: TV (0)
HDMI port number: 1
physical address: 1.0.0.0
compiled on Windows-6.2 (x64)
features: P8_USB
P8_detect
```

As you see, the physical address along with any reported base device isn't reliably the same, but can depend on whether base devices are powered on or off.

Another issue is that the application only accepts commands from the TV (0) device and not the Audio (5) device.

Both of the issues have been solved by not parsing the initialization string for the base device, but rather accept commands coming from both TV (0) and Audio (5).

This change in the code works well for my system, and if there are no glaring issues with this, it would be cool if it could be merged into the main repo.